### PR TITLE
Add missing finalizer RBAC for Guacamole resource

### DIFF
--- a/config/crd/bases/guacamole-operator.github.io_guacamoles.yaml
+++ b/config/crd/bases/guacamole-operator.github.io_guacamoles.yaml
@@ -153,6 +153,76 @@ spec:
           status:
             description: GuacamoleStatus defines the observed state of Guacamole.
             properties:
+              conditions:
+                description: Conditions follows the API specification "Conditions"
+                  properties. https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
               errors:
                 items:
                   type: string

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -81,6 +81,12 @@ rules:
 - apiGroups:
   - guacamole-operator.github.io
   resources:
+  - guacamoles/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - guacamole-operator.github.io
+  resources:
   - guacamoles/status
   verbs:
   - get

--- a/controllers/guacamole_controller.go
+++ b/controllers/guacamole_controller.go
@@ -46,6 +46,7 @@ type GuacamoleReconciler struct {
 
 // +kubebuilder:rbac:groups=guacamole-operator.github.io,resources=guacamoles,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=guacamole-operator.github.io,resources=guacamoles/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=guacamole-operator.github.io,resources=guacamoles/finalizers,verbs=update
 //
 // +kubebuilder:rbac:groups="",resources=services;serviceaccounts;secrets;configmaps,verbs=get;list;watch;create;update;delete;patch
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;delete;patch
@@ -65,7 +66,7 @@ func (r *GuacamoleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		declarative.WithObjectTransform(declarative.AddLabels(labels)),
 		declarative.WithOwner(declarative.SourceAsOwner),
 		declarative.WithLabels(watchLabels),
-		declarative.WithStatus(status.NewBasic(mgr.GetClient())),
+		declarative.WithStatus(status.NewKstatusCheck(mgr.GetClient(), &r.Reconciler)),
 		declarative.WithObjectTransform(addon.ApplyPatches),
 		declarative.WithApplyKustomize(),
 	); err != nil {


### PR DESCRIPTION
The kubebuilder-declarative-pattern did not generate the necessary RBAC permissions to update finalizers on the CRD.

In clusters with enabled OwnerReferencesPermissionEnforcement, this will result in errors otherwise.