### PR TITLE
Set GUACD_PORT always

### DIFF
--- a/channels/packages/guacamole/0.0.1/guacamole.yaml
+++ b/channels/packages/guacamole/0.0.1/guacamole.yaml
@@ -60,6 +60,8 @@ spec:
           env:
             - name: GUACD_HOSTNAME
               value: guacd
+            - name: GUACD_PORT
+              value: "4822"
           ports:
             - name: http
               containerPort: 8080


### PR DESCRIPTION
It will get overwritten with k8s service discovery environment variables otherwise.