### PR TITLE
Downgrade default guacd to 1.4.0

### DIFF
--- a/channels/packages/guacamole/0.0.1/kustomization.yaml
+++ b/channels/packages/guacamole/0.0.1/kustomization.yaml
@@ -9,6 +9,6 @@ resources:
 
 images:
   - name: docker.io/guacamole/guacd:latest
-    newTag: 1.5.0
+    newTag: 1.4.0
   - name: docker.io/guacamole/guacamole:latest
     newTag: 1.5.0


### PR DESCRIPTION
Due to the following bug https://issues.apache.org/jira/browse/GUACAMOLE-1741,
vnc connections can sometimes not be established. Until 1.5.1 is released,
the default guacd version is downgraded, which seems to work fine.