### PR TITLE
Fix connection update errors when already existent

### DIFF
--- a/controllers/connection_controller.go
+++ b/controllers/connection_controller.go
@@ -62,7 +62,7 @@ type ConnectionReconciler struct {
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.13.0/pkg/reconcile
 func (r *ConnectionReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	logger := log.FromContext(ctx).WithValues("connection", req.NamespacedName)
+	logger := log.FromContext(ctx)
 
 	// Fetch instance.
 	connection := &v1alpha1.Connection{}

--- a/internal/client/gen/client.gen.go
+++ b/internal/client/gen/client.gen.go
@@ -2829,7 +2829,7 @@ func (r DeleteConnectionResponse) StatusCode() int {
 type GetConnectionResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *Connections
+	JSON200      *Connection
 }
 
 // Status returns HTTPResponse.Status
@@ -4069,7 +4069,7 @@ func ParseGetConnectionResponse(rsp *http.Response) (*GetConnectionResponse, err
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest Connections
+		var dest Connection
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
If a connection was not reconciled correctly and had missing identity /
parameter status fields, while a connection was created in the instance,
the reconciling would fail with "already existing" errors. Now, the
reconciliation does not rely on existing status information and infers
necessary parameters. This will also check for already existent
connections in the instance.

If a connection is managed by a CR it will now take control of existing
connections within the instance, even if it was created manually.

Connections can now change parent groups. If a connection changes its
parent and a conflicting connection is already in-place, no
modifications will occur and the reconciliation fails. This corresponds
to the upstream behavior.

Remove unnecessary log of connection resource name and namespace.