### PR TITLE
Update Guacamole to 1.5.1

### DIFF
--- a/channels/packages/guacamole/0.0.1/kustomization.yaml
+++ b/channels/packages/guacamole/0.0.1/kustomization.yaml
@@ -8,6 +8,6 @@ resources:
 
 images:
   - name: docker.io/guacamole/guacd:latest
-    newTag: 1.4.0
+    newTag: 1.5.1
   - name: docker.io/guacamole/guacamole:latest
-    newTag: 1.5.0
+    newTag: 1.5.1


### PR DESCRIPTION
This should also fix a problem with guacd authenticating with VNC https://issues.apache.org/jira/browse/GUACAMOLE-1741.