### PR TITLE
Fix init container initdb parameter

### DIFF
--- a/internal/transformer/guacamole.go
+++ b/internal/transformer/guacamole.go
@@ -164,7 +164,7 @@ func postgresInitContainer(guacImage string) []corev1.Container {
 		},
 		Args: []string{
 			"-c",
-			"/opt/guacamole/bin/initdb.sh --postgres > /data/initdb.sql",
+			"/opt/guacamole/bin/initdb.sh --postgresql > /data/initdb.sql",
 		},
 	}
 


### PR DESCRIPTION
Guacamole 1.5.2 had a change in the handling of postgres parameters (e.g. in env vars). The parameter to generate the db init script for postgres has to be adapted as well.