### PR TITLE
Make user and group in permissions optional

### DIFF
--- a/api/v1alpha1/connection_types.go
+++ b/api/v1alpha1/connection_types.go
@@ -118,10 +118,14 @@ type ConnectionParameters struct {
 type ConnectionPermissions struct {
 	// Users with permissions on the connection.
 	// As in upstream UI, users will get READ permissions.
-	Users []ConnectionUser `json:"users"`
+	//
+	// +optional
+	Users []ConnectionUser `json:"users,omitempty"`
 	// User groups with permissions on the connection.
 	// As in upstream UI, groups will get READ permissions.
-	Groups []ConnectionGroup `json:"groups"`
+	//
+	// +optional
+	Groups []ConnectionGroup `json:"groups,omitempty"`
 }
 
 // ConnectionUser...

--- a/config/crd/bases/guacamole-operator.github.io_connections.yaml
+++ b/config/crd/bases/guacamole-operator.github.io_connections.yaml
@@ -87,9 +87,6 @@ spec:
                       - id
                       type: object
                     type: array
-                required:
-                - groups
-                - users
                 type: object
               protocol:
                 description: Protocol of the connection.


### PR DESCRIPTION
Users and groups within the permissions are now an optional field.