### PR TITLE
Propagate cluster proxy for extension downloader

### DIFF
--- a/internal/transformer/guacamole.go
+++ b/internal/transformer/guacamole.go
@@ -298,6 +298,15 @@ func applyExtensions(extensions []v1alpha1.Extension, m *manifest.Objects) error
 				Args:  extUris,
 			}
 
+			// Apply cluster proxy.
+			for _, v := range getProxyVariables() {
+				if v.Value == "" {
+					continue
+				}
+
+				downloaderContainer.Env = append(downloaderContainer.Env, v)
+			}
+
 			deployment.Spec.Template.Spec.InitContainers = []corev1.Container{downloaderContainer}
 
 			// Mount emptyDir volume to place extensions.

--- a/internal/transformer/utils.go
+++ b/internal/transformer/utils.go
@@ -1,9 +1,27 @@
 package transformer
 
 import (
+	"os"
+
+	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/kubebuilder-declarative-pattern/pkg/patterns/declarative/pkg/manifest"
 )
 
 func isDeployment(obj *manifest.Object) bool {
 	return obj.Kind == "Deployment"
+}
+
+func getProxyVariables() []corev1.EnvVar {
+	proxyEnv := []corev1.EnvVar{{
+		Name:  "HTTPS_PROXY",
+		Value: os.Getenv("HTTPS_PROXY"),
+	}, {
+		Name:  "HTTP_PROXY",
+		Value: os.Getenv("HTTP_PROXY"),
+	}, {
+		Name:  "NO_PROXY",
+		Value: os.Getenv("NO_PROXY"),
+	}}
+
+	return proxyEnv
 }


### PR DESCRIPTION
Extension downloader init container should likely use a cluster proxy if available.