### PR TITLE
Fix handling for the extensions volume

### DIFF
--- a/channels/packages/guacamole/0.0.1/guacamole.yaml
+++ b/channels/packages/guacamole/0.0.1/guacamole.yaml
@@ -75,10 +75,6 @@ spec:
               value: guacd
             - name: GUACD_PORT
               value: "4822"
-          volumeMounts:
-            - name: extensions
-              mountPath: /extensions
-              optional: true
           ports:
             - name: http
               containerPort: 8080

--- a/internal/transformer/guacamole.go
+++ b/internal/transformer/guacamole.go
@@ -19,7 +19,7 @@ import (
 
 const (
 	GuacamoleDeploymentName = "guacamole"
-	extensionDLImage        = "ghcr.io/guacamole-operator/extension-dl:025675e"
+	extensionDLImage        = "ghcr.io/guacamole-operator/extension-dl:277d1ab"
 )
 
 // Guacamole transform the guacamole deployment manifest.
@@ -320,6 +320,12 @@ func applyExtensions(extensions []v1alpha1.Extension, m *manifest.Objects) error
 			ensureInitContainerVolumeMount(&deployment, "extension-dl", corev1.VolumeMount{
 				Name: "extensions",
 				// GUACAMOLE_HOME=/tmp/guacamole required.
+				MountPath: "/extensions",
+			})
+
+			ensureContainerVolumeMount(&deployment, "guacamole", corev1.VolumeMount{
+				Name:      "extensions",
+				ReadOnly:  true,
 				MountPath: "/extensions",
 			})
 


### PR DESCRIPTION
- Remove Wrong volume mount definition within channels. 
- Ensure volume mounts for extensions within guacamole deployment. 
- Update `extension-dl` image version.