### PR TITLE
Update `golangci-lint` configuration to v2

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -15,7 +15,7 @@ jobs:
         with:
           go-version-file: go.mod
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v8
         with:
           version: latest
           args: --timeout 3m --verbose

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,34 +1,56 @@
+version: "2"
 linters:
-  # Additionally enabled linters.
   enable:
+    - copyloopvar
     - dogsled
     - dupl
     - exhaustive
-    - copyloopvar
     - goconst
     - godot
-    - gofumpt
-    - goimports
-    - mnd
     - importas
+    - mnd
     - revive
     - unconvert
     - unparam
     - whitespace
-  fast: false
-linters-settings:
-  exhaustive:
-    default-signifies-exhaustive: true
-  importas:
-    alias:
-      - pkg: k8s.io/api/core/v1
-        alias: corev1
-      - pkg: k8s.io/apimachinery/pkg/apis/meta/v1
-        alias: metav1
-  revive:
-    rules:
-      - name: dot-imports
-        arguments:
-          - allowedPackages:
-              - github.com/onsi/ginkgo/v2
-              - github.com/onsi/gomega
+  settings:
+    exhaustive:
+      default-signifies-exhaustive: true
+    importas:
+      alias:
+        - pkg: k8s.io/api/core/v1
+          alias: corev1
+        - pkg: k8s.io/apimachinery/pkg/apis/meta/v1
+          alias: metav1
+    revive:
+      rules:
+        - name: dot-imports
+          arguments:
+            - allowedPackages:
+                - github.com/onsi/ginkgo/v2
+                - github.com/onsi/gomega
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofumpt
+    - goimports
+  settings:
+    goimports:
+      local-prefixes:
+        - github.com/guacamole-operator/guacamole-operator
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,9 +11,12 @@
       "source.organizeImports": "explicit"
     },
   },
-  "go.lintTool": "golangci-lint",
+  "go.lintTool": "golangci-lint-v2",
   "go.lintFlags": [
     "--fix"
   ],
   "go.lintOnSave": "workspace",
+  "gopls": {
+    "formatting.gofumpt": true,
+  }
 }

--- a/api/v1alpha1/connection_types.go
+++ b/api/v1alpha1/connection_types.go
@@ -19,8 +19,9 @@ package v1alpha1
 import (
 	"encoding/json"
 
-	"github.com/guacamole-operator/guacamole-operator/internal/client/gen"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/guacamole-operator/guacamole-operator/internal/client/gen"
 )
 
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.

--- a/controllers/connection_controller.go
+++ b/controllers/connection_controller.go
@@ -38,7 +38,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/guacamole-operator/guacamole-operator/api/v1alpha1"
-	guacamoleoperatorgithubiov1alpha1 "github.com/guacamole-operator/guacamole-operator/api/v1alpha1"
 	guacclient "github.com/guacamole-operator/guacamole-operator/internal/client"
 	reconciler "github.com/guacamole-operator/guacamole-operator/internal/reconciler/connection"
 )
@@ -179,7 +178,7 @@ func (r *ConnectionReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	}
 
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&guacamoleoperatorgithubiov1alpha1.Connection{}).
+		For(&v1alpha1.Connection{}).
 		Watches(
 			&v1alpha1.Guacamole{},
 			r.watchGuacamoleRef(fieldToIndex),
@@ -286,19 +285,19 @@ func (r *ConnectionReconciler) getConnectionParams(ctx context.Context, obj *v1a
 
 	err := r.Get(ctx, types.NamespacedName{Name: secret.Name, Namespace: secret.Namespace}, &secret)
 	if err != nil && k8serrors.IsNotFound(err) {
-		return nil, fmt.Errorf("Guacamole access parameters secret not found: %w", err)
+		return nil, fmt.Errorf("access parameters secret not found: %w", err)
 	}
 
 	errInvalidParamaters := errors.New("invalid parameters")
 
 	username, ok := secret.Data["username"]
 	if !ok {
-		return nil, fmt.Errorf("Guacamole username parameter missing: %w", errInvalidParamaters)
+		return nil, fmt.Errorf("username parameter missing: %w", errInvalidParamaters)
 	}
 
 	password, ok := secret.Data["password"]
 	if !ok {
-		return nil, fmt.Errorf("Guacamole password parameter missing: %w", errInvalidParamaters)
+		return nil, fmt.Errorf("password parameter missing: %w", errInvalidParamaters)
 	}
 
 	clientConfig.Username = string(username)

--- a/controllers/guacamole_controller.go
+++ b/controllers/guacamole_controller.go
@@ -59,7 +59,7 @@ type GuacamoleReconciler struct {
 func (r *GuacamoleReconciler) setupReconciler(mgr ctrl.Manager) error {
 	r.watchLabels = declarative.SourceLabel(mgr.GetScheme())
 
-	return r.Reconciler.Init(mgr, &guacamolev1alpha1.Guacamole{},
+	return r.Init(mgr, &guacamolev1alpha1.Guacamole{},
 		declarative.WithOwner(declarative.SourceAsOwner),
 		declarative.WithLabels(r.watchLabels),
 		declarative.WithStatus(status.NewKstatusCheck(mgr.GetClient(), &r.Reconciler)),

--- a/internal/transformer/guacd.go
+++ b/internal/transformer/guacd.go
@@ -46,17 +46,17 @@ func applyAnnotations(objMeta *v1alpha1.ObjectMeta, m *manifest.Objects) error {
 			annotations := objMeta.Annotations
 
 			// Merge annotations.
-			if deployment.ObjectMeta.Annotations == nil {
-				deployment.ObjectMeta.Annotations = make(map[string]string)
+			if deployment.Annotations == nil {
+				deployment.Annotations = make(map[string]string)
 			}
 
-			maps.Insert(deployment.ObjectMeta.Annotations, maps.All(annotations))
+			maps.Insert(deployment.Annotations, maps.All(annotations))
 
 			// Merge template annotations.
-			if deployment.Spec.Template.ObjectMeta.Annotations == nil {
-				deployment.Spec.Template.ObjectMeta.Annotations = make(map[string]string)
+			if deployment.Spec.Template.Annotations == nil {
+				deployment.Spec.Template.Annotations = make(map[string]string)
 			}
-			maps.Insert(deployment.Spec.Template.ObjectMeta.Annotations, maps.All(annotations))
+			maps.Insert(deployment.Spec.Template.Annotations, maps.All(annotations))
 
 			u, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&deployment)
 			if err != nil {


### PR DESCRIPTION
Run migration to new configuration format. Change `vscode` settings. Fix warnings.

Note:
At the time of writing, the `pre-release` version of the `Go` extension has to be used for v2 support.