### PR TITLE
Update to Guacamole 1.6.0

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.24.3 as builder
+FROM golang:1.24.4 as builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/channels/packages/guacamole/0.0.2/kustomization.yaml
+++ b/channels/packages/guacamole/0.0.2/kustomization.yaml
@@ -8,6 +8,6 @@ resources:
 
 images:
   - name: docker.io/guacamole/guacd:latest
-    newTag: 1.6.0-RC1
+    newTag: 1.6.0
   - name: docker.io/guacamole/guacamole:latest
-    newTag: 1.6.0-RC1
+    newTag: 1.6.0


### PR DESCRIPTION
Update default Guacamole version to 1.6.0.