### PR TITLE
Do not reconcile connections on status updates

### DIFF
--- a/controllers/connection_controller.go
+++ b/controllers/connection_controller.go
@@ -188,7 +188,7 @@ func (r *ConnectionReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	}
 
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&v1alpha1.Connection{}).
+		For(&v1alpha1.Connection{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Watches(
 			&v1alpha1.Guacamole{},
 			r.watchGuacamoleRef(fieldToIndex),


### PR DESCRIPTION
Reconciling on status updates is unnecessary for the controller but doubles the execution time. Set predicate to trigger only on changed generation.