### PR TITLE
Add setup for local tests

### DIFF
--- a/hack/guacamole.yaml
+++ b/hack/guacamole.yaml
@@ -1,0 +1,223 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: postgres
+spec:
+  containers:
+    - name: postgres
+      image: docker.io/library/postgres:17
+      env:
+        - name: POSTGRES_USER
+          valueFrom:
+            secretKeyRef:
+              name: pg-app
+              key: username
+        - name: POSTGRES_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: pg-app
+              key: password
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: guacd
+spec:
+  containers:
+    - name: guacd
+      image: docker.io/guacamole/guacd:latest
+      ports:
+        - name: guacd
+          containerPort: 4822
+          protocol: TCP
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: guacamole
+spec:
+  initContainers:
+    - name: create-init-db
+      command:
+        - /bin/sh
+      securityContext:
+        capabilities:
+          drop:
+            - MKNOD
+      volumeMounts:
+        - name: initdb
+          mountPath: /data
+      image: "docker.io/guacamole/guacamole:1.6.0"
+      args:
+        - "-c"
+        - /opt/guacamole/bin/initdb.sh --postgresql > /data/initdb.sql
+    - name: load-db
+      command:
+        - /bin/sh
+      env:
+        - name: POSTGRESQL_HOSTNAME
+          valueFrom:
+            secretKeyRef:
+              name: pg-app
+              key: host
+        - name: POSTGRESQL_PORT
+          valueFrom:
+            secretKeyRef:
+              name: pg-app
+              key: port
+        - name: POSTGRESQL_DATABASE
+          valueFrom:
+            secretKeyRef:
+              name: pg-app
+              key: dbname
+        - name: POSTGRESQL_USER
+          valueFrom:
+            secretKeyRef:
+              name: pg-app
+              key: user
+        - name: POSTGRESQL_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: pg-app
+              key: password
+      securityContext:
+        capabilities:
+          drop:
+            - MKNOD
+      volumeMounts:
+        - name: initdb
+          mountPath: /data
+      image: "docker.io/library/postgres:alpine"
+      args:
+        - "-c"
+        - |-
+          export PGPASSWORD=$POSTGRESQL_PASSWORD
+          MAX_RETRIES=30
+          i=1
+          while [ "$i" -le $MAX_RETRIES ]
+          do
+              if pg_isready -h $POSTGRESQL_HOSTNAME -d $POSTGRESQL_DATABASE -U $POSTGRESQL_USER -p $POSTGRESQL_PORT; then
+                  echo "Database is ready to accept connections."
+                  psql -h $POSTGRESQL_HOSTNAME -d $POSTGRESQL_DATABASE -U $POSTGRESQL_USER -p $POSTGRESQL_PORT -a -w -f /data/initdb.sql || true
+                  exit 0
+              fi
+              echo "Waiting for PG database."
+              sleep 4
+              i=$((i + 1))
+          done
+          exit 1
+  containers:
+    - name: guacamole
+      image: docker.io/guacamole/guacamole:latest
+      command:
+        - /bin/bash
+      args:
+        - -c
+        - |
+          set -e
+
+          # Import ca-certs.
+          if [ -d "/opt/ca-bundle" ]; then
+            echo "Importing ca-certificates."
+
+            CERTFILES=$(find /opt/ca-bundle -mindepth 1 -maxdepth 1 -name '*.pem')
+
+            for CERTFILE in $CERTFILES; do
+                # Remove path, then suffix to derive alias from filename
+                ALIAS=${CERTFILE##*/}
+                ALIAS=${ALIAS%.*}
+                $JAVA_HOME/bin/keytool \
+                  -importcert \
+                  -file "$CERTFILE" \
+                  -alias "$ALIAS" \
+                  -trustcacerts \
+                  -storepass changeit \
+                  -noprompt
+
+                if [ $? -ne 0 ]; then
+                    echo "Failed to add $CERTFILE as $ALIAS to keystore"
+                    exit 1
+                fi
+
+                # Use user keystore, as system keystore is not writable in the used container.
+                # Disadvantage is, that regular public CAs are not used anymore.
+                export JAVA_OPTS="$JAVA_OPTS -Djavax.net.ssl.trustStore=$HOME/.keystore"
+                export JAVA_OPTS="$JAVA_OPTS -Djavax.net.ssl.trustStorePassword=changeit"
+            done
+          fi
+
+          # The home directory template used by the container entrypoint.
+          # Needed to inject properties and extensions.
+          export GUACAMOLE_HOME=/tmp/guacamole
+          mkdir -p "${GUACAMOLE_HOME}"
+
+          # Configure extensions.
+          mkdir -p "${GUACAMOLE_HOME}/extensions"
+          [ -d "/extensions" ] && cp -r /extensions/. "${GUACAMOLE_HOME}/extensions"
+
+          # Configure lib.
+          mkdir -p "${GUACAMOLE_HOME}/lib"
+
+          # Workaround for https://github.com/apache/guacamole-client/pull/794
+          # not being backported to version 1.5.x.
+          printf "enable-environment-properties: true\n" > "${GUACAMOLE_HOME}/guacamole.properties"
+
+          # Run original entrypoint.
+          /opt/guacamole/bin/entrypoint.sh
+      env:
+        - name: GUACD_HOSTNAME
+          value: guacd
+        - name: GUACD_PORT
+          value: "4822"
+        - name: POSTGRESQL_HOSTNAME
+          valueFrom:
+            secretKeyRef:
+              name: pg-app
+              key: host
+        - name: POSTGRESQL_PORT
+          valueFrom:
+            secretKeyRef:
+              name: pg-app
+              key: port
+        - name: POSTGRESQL_DATABASE
+          valueFrom:
+            secretKeyRef:
+              name: pg-app
+              key: dbname
+        - name: POSTGRESQL_USER
+          valueFrom:
+            secretKeyRef:
+              name: pg-app
+              key: user
+        - name: POSTGRESQL_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: pg-app
+              key: password
+      ports:
+        - name: http
+          containerPort: 8080
+          protocol: TCP
+          hostPort: 8080
+      livenessProbe:
+        httpGet:
+          path: /guacamole
+          port: http
+        initialDelaySeconds: 10
+        periodSeconds: 5
+  volumes:
+    - name: initdb
+      emptyDir: {}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: pg-app
+type: kubernetes.io/basic-auth
+stringData:
+  port: 5432
+  host: postgres
+  dbname: app
+  user: app
+  username: app
+  password: app


### PR DESCRIPTION
Define resources for `podman kube` to run Guacamole instance and database locally.