### PR TITLE
Allow env var config and expose further settings

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -22,9 +22,6 @@ linters:
           alias: corev1
         - pkg: k8s.io/apimachinery/pkg/apis/meta/v1
           alias: metav1
-    mnd:
-      ignored-functions:
-        - '^flag\.'
     revive:
       rules:
         - name: dot-imports

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,37 @@
+package config
+
+import (
+	"os"
+	"strconv"
+)
+
+// EnvOrDefault returns the value of an environment variable
+// or the default value.
+func EnvOrDefault(key, defaultValue string) string {
+	if value, exists := os.LookupEnv(key); exists {
+		return value
+	}
+	return defaultValue
+}
+
+// EnvIntOrDefault returns the value of an environment variable
+// or the default value.
+func EnvIntOrDefault(key string, defaultValue int) int {
+	if value, exists := os.LookupEnv(key); exists {
+		if parsed, err := strconv.Atoi(value); err == nil {
+			return parsed
+		}
+	}
+	return defaultValue
+}
+
+// EnvBoolOrDefault returns the value of an environment variable
+// or the default value.
+func EnvBoolOrDefault(key string, defaultValue bool) bool {
+	if value, exists := os.LookupEnv(key); exists {
+		if parsed, err := strconv.ParseBool(value); err == nil {
+			return parsed
+		}
+	}
+	return defaultValue
+}


### PR DESCRIPTION
- Allow settings to be provided by environment variables. Flags have higher priority.
- Expose setting for concurrent connection reconciles.
- Expose setting for the new priority queue currently in beta status in `controller-runtime`.