### PR TITLE
Add event listener for `cloudevents` extension

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.24.5 as builder
+FROM docker.io/library/golang:1.24.5 as builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/guacamole-operator/guacamole-operator
 
-go 1.24.4
+go 1.24.5
 
 require (
 	github.com/cloudevents/sdk-go/v2 v2.16.1

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/guacamole-operator/guacamole-operator
 go 1.24.4
 
 require (
+	github.com/cloudevents/sdk-go/v2 v2.16.1
 	github.com/coder/websocket v1.8.13
 	github.com/go-logr/logr v1.4.3
 	github.com/google/go-cmp v0.7.0
@@ -96,6 +97,8 @@ require (
 	github.com/xanzy/ssh-agent v0.3.3 // indirect
 	github.com/xlab/treeprint v1.2.0 // indirect
 	go.uber.org/automaxprocs v1.6.0 // indirect
+	go.uber.org/multierr v1.11.0 // indirect
+	go.uber.org/zap v1.27.0 // indirect
 	golang.org/x/crypto v0.39.0 // indirect
 	golang.org/x/mod v0.25.0 // indirect
 	golang.org/x/net v0.41.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -53,6 +53,8 @@ github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWR
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
+github.com/cloudevents/sdk-go/v2 v2.16.1 h1:G91iUdqvl88BZ1GYYr9vScTj5zzXSyEuqbfE63gbu9Q=
+github.com/cloudevents/sdk-go/v2 v2.16.1/go.mod h1:v/kVOaWjNfbvc6tkhhlkhvLapj8Aa8kvXiH5GiOHCKI=
 github.com/cloudflare/circl v1.6.1 h1:zqIqSPIndyBh1bjLVVDHMPpVKqp8Su/V+6MeDzzQBQ0=
 github.com/cloudflare/circl v1.6.1/go.mod h1:uddAzsPgqdMAYatqJ0lsjX1oECcQLIlRpzZh3pJrofs=
 github.com/coder/websocket v1.8.13 h1:f3QZdXy7uGVz+4uCJy2nTZyM0yTBj8yANEHhqlXZ9FE=
@@ -439,6 +441,8 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/ugorji/go/codec v1.2.11 h1:BMaWp1Bb6fHwEtbplGBGJ498wD+LKlNSl25MjdZY4dU=
 github.com/ugorji/go/codec v1.2.11/go.mod h1:UNopzCgEMSXjBc6AOMqYvWC1ktqTAfzJZUZgYf6w6lg=
+github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=
+github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/vmware-labs/yaml-jsonpath v0.3.2 h1:/5QKeCBGdsInyDCyVNLbXyilb61MXGi9NP674f9Hobk=
 github.com/vmware-labs/yaml-jsonpath v0.3.2/go.mod h1:U6whw1z03QyqgWdgXxvVnQ90zN1BWz5V+51Ewf8k+rQ=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=

--- a/internal/listener/events.go
+++ b/internal/listener/events.go
@@ -1,0 +1,26 @@
+package listener
+
+// userData defines the content of user related CloudEvent.
+type userData struct {
+	// Username of user.
+	Username string `json:"username"`
+}
+
+// event implements controllers.GuacamoleEvent.
+type event struct {
+	name      string
+	namespace string
+	user      string
+}
+
+func (e *event) Name() string {
+	return e.name
+}
+
+func (e *event) Namespace() string {
+	return e.namespace
+}
+
+func (e *event) Username() string {
+	return e.user
+}

--- a/internal/listener/listener.go
+++ b/internal/listener/listener.go
@@ -1,0 +1,172 @@
+package listener
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"slices"
+	"sync"
+
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+
+	"github.com/guacamole-operator/guacamole-operator/controllers"
+	"github.com/guacamole-operator/guacamole-operator/internal/ws"
+)
+
+// id identifies a Guacamole instance by its name and namespace.
+type id struct {
+	Namespace string
+	Name      string
+}
+
+// client encapsulates a WebSocket client and holds its relevant
+// channels and context cancel functions.
+type client struct {
+	*ws.Client
+	dataCh <-chan []byte
+	errCh  <-chan error
+	cancel context.CancelFunc
+}
+
+// Listener implements an event listener for CloudEvents produced by the
+// custom Guacamole `cloudevents` extension.
+type Listener struct {
+	// WebSocket clients per Guacamole instance.
+	clients map[id]*client
+	mutex   sync.RWMutex
+}
+
+// Add a WebSocket Client for a Guacamole Instance.
+func (l *Listener) Add(namespace, name, URL string) {
+	if l.clients == nil {
+		l.clients = make(map[id]*client)
+	}
+
+	id := id{
+		Namespace: namespace,
+		Name:      name,
+	}
+
+	if _, exists := l.clients[id]; exists {
+		return
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	dataCh := make(chan []byte, 1)
+	errCh := make(chan error, 1)
+
+	client := client{
+		Client: ws.New(URL),
+		dataCh: dataCh,
+		errCh:  errCh,
+		cancel: cancel,
+	}
+
+	go client.Read(ctx, dataCh, errCh)
+	l.clients[id] = &client
+}
+
+// Remove a WebSocket client for a Guacamole instance
+// and close the connection.
+func (l *Listener) Remove(namespace, name string) {
+	id := id{
+		Namespace: namespace,
+		Name:      name,
+	}
+
+	client, exists := l.clients[id]
+	if !exists {
+		return
+	}
+
+	l.mutex.Lock()
+	defer l.mutex.Unlock()
+
+	client.cancel()
+	client.Close()
+
+	delete(l.clients, id)
+}
+
+// Listen for events from all clients.
+func (l *Listener) Listen(ctx context.Context, eventCh chan<- controllers.GuacamoleWrappedEvent, errCh chan<- error, doneCh chan<- struct{}) {
+	for {
+		if err := ctx.Err(); err != nil {
+			break
+		}
+
+		for id, client := range l.clients {
+			func() {
+				l.mutex.RLock()
+				defer l.mutex.RUnlock()
+
+				select {
+				case msg := <-client.dataCh:
+					user, ok, err := getEventUser(msg)
+					if err != nil {
+						errCh <- fmt.Errorf("%s in %s: %w", id.Name, id.Namespace, err)
+					}
+
+					if !ok {
+						break
+					}
+
+					e := controllers.GuacamoleWrappedEvent{
+						Object: &event{
+							namespace: id.Namespace,
+							name:      id.Name,
+							user:      user,
+						},
+					}
+
+					eventCh <- e
+
+				case err := <-client.errCh:
+					errCh <- fmt.Errorf("%s in %s: %w", id.Name, id.Namespace, err)
+
+				default:
+				}
+			}()
+		}
+	}
+
+	// Cancel all `Read` goroutines and close the client's connection.
+	for _, client := range l.clients {
+		client.cancel()
+		client.Close()
+	}
+
+	close(doneCh)
+}
+
+// getEventUser checks if a CloudEvent is a user related event
+// and extracts the username. Only successful create, update
+// or delete events are considered.
+func getEventUser(msg []byte) (string, bool, error) {
+	// Read CloudEvent.
+	ce := cloudevents.NewEvent()
+	err := json.Unmarshal(msg, &ce)
+	if err != nil {
+		return "", false, err
+	}
+
+	// Filter all valid user success events.
+	validEventTypes := []string{
+		"io.github.guacamole_operator.user.success.create",
+		"io.github.guacamole_operator.user.success.update",
+		"io.github.guacamole_operator.user.success.delete",
+	}
+
+	if !slices.Contains(validEventTypes, ce.Context.GetType()) {
+		return "", false, nil
+	}
+
+	// Extract username from event.
+	var user userData
+	err = json.Unmarshal(ce.Data(), &user)
+	if err != nil {
+		return "", false, err
+	}
+
+	return user.Username, true, nil
+}


### PR DESCRIPTION
Add event listener for the custom `cloudevents` extension. `Guacamole` instances can be marked with an annotation to have the events processed. User events then trigger the `Connection` reconciler to resync connections a user has permissions on.

The overall implementation is gated via a feature flag for now.