### PR TITLE
Check connection permissions for guacamole events

### DIFF
--- a/controllers/connection_controller.go
+++ b/controllers/connection_controller.go
@@ -311,6 +311,10 @@ func (r *ConnectionReconciler) guacamoleEventRequestMapFunc(indexField string) g
 		var requests []reconcile.Request
 
 		for _, c := range connections.Items {
+			if c.Spec.Permissions == nil {
+				continue
+			}
+
 			if !slices.Contains(c.Spec.Permissions.Users, v1alpha1.ConnectionUser{ID: obj.Username()}) {
 				continue
 			}


### PR DESCRIPTION
Current implementation causes a panic if event occured and the connection permissions are `nil`.
Add an additional `nil` for permissions while guacamole event handling.